### PR TITLE
Revert "proc: make oom adjustment files user read-only"

### DIFF
--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -2876,8 +2876,8 @@ static const struct pid_entry tgid_base_stuff[] = {
 	ONE("cgroup",  S_IRUGO, proc_cgroup_show),
 #endif
 	ONE("oom_score",  S_IRUGO, proc_oom_score),
-	REG("oom_adj",    S_IRUSR, proc_oom_adj_operations),
-	REG("oom_score_adj", S_IRUSR, proc_oom_score_adj_operations),
+	REG("oom_adj",    S_IRUGO|S_IWUSR, proc_oom_adj_operations),
+	REG("oom_score_adj", S_IRUGO|S_IWUSR, proc_oom_score_adj_operations),
 #ifdef CONFIG_AUDITSYSCALL
 	REG("loginuid",   S_IWUSR|S_IRUGO, proc_loginuid_operations),
 	REG("sessionid",  S_IRUGO, proc_sessionid_operations),
@@ -3267,8 +3267,8 @@ static const struct pid_entry tid_base_stuff[] = {
 	ONE("cgroup",  S_IRUGO, proc_cgroup_show),
 #endif
 	ONE("oom_score", S_IRUGO, proc_oom_score),
-	REG("oom_adj",   S_IRUSR, proc_oom_adj_operations),
-	REG("oom_score_adj", S_IRUSR, proc_oom_score_adj_operations),
+	REG("oom_adj",   S_IRUGO|S_IWUSR, proc_oom_adj_operations),
+	REG("oom_score_adj", S_IRUGO|S_IWUSR, proc_oom_score_adj_operations),
 #ifdef CONFIG_AUDITSYSCALL
 	REG("loginuid",  S_IWUSR|S_IRUGO, proc_loginuid_operations),
 	REG("sessionid",  S_IRUGO, proc_sessionid_operations),


### PR DESCRIPTION
This reverts commit 55541f1ac36fbb6edd94273cab21d69a82d31519.

This is a downstream change from Android / CrOS that was brought with
linux-rockchip. There is more info on [1], but in summary there used to
be a suid helper that enforced a policy on OOM score changes in order to
prevent malicious apps from becoming immortals. According [1] this patch
is now dropped from the Android / CrOS kernel as well.

The original commit prevents Chromium from making less important tabs
and processes more likely to get killed by the OOM killer, with the
following error being printed for every new tab.

  Sep 30 07:11:45 endless-arm xdg-desktop-portal[2984]:
  [2997:3072:0930/071145.742382:ERROR:zygote_host_impl_linux.cc(263)]
  Failed to adjust OOM score of renderer with pid 5590: Permission
  denied (13)

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=576409

https://phabricator.endlessm.com/T23933